### PR TITLE
REL-4333 Apply patches from Oracle to build against system openssl

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -319,7 +319,12 @@ EOM
         @{ $opts->{lib_links} } = map { $_ =~ s/32\b//g } @{ $opts->{lib_links} } if $Config{use64bitall};
     }
     else {
-        push @{ $opts->{lib_links} }, qw( ssl crypto z );
+        if ( eval { require ExtUtils::PkgConfig; ExtUtils::PkgConfig->VERSION('1.16') } && ExtUtils::PkgConfig->exists('openssl') ) {
+            push @{ $opts->{lib_links} }, map { s/^-l//; $_ } split(' ', ExtUtils::PkgConfig->libs_only_l('openssl'));
+        }
+        else {
+             push @{ $opts->{lib_links} }, qw( ssl crypto z );
+        }
 
         if (($Config{cc} =~ /aCC/i) && $^O eq 'hpux') {
             print "*** Enabling HPUX aCC options (+e)\n";

--- a/t/local/44_sess.t
+++ b/t/local/44_sess.t
@@ -14,13 +14,13 @@ use English qw( $EVAL_ERROR $OSNAME $PERL_VERSION -no_match_vars );
 if (not can_fork()) {
     plan skip_all => "fork() not supported on this system";
 } else {
-    plan tests => 67;
+    plan tests => 39;
 }
 
 initialise_libssl();
 
 my @rounds = qw(
-    TLSv1 TLSv1.1 TLSv1.2 TLSv1.3 TLSv1.3-num-tickets-ssl
+    TLSv1.2 TLSv1.3 TLSv1.3-num-tickets-ssl
     TLSv1.3-num-tickets-ctx-6 TLSv1.3-num-tickets-ctx-0
 );
 

--- a/t/local/45_exporter.t
+++ b/t/local/45_exporter.t
@@ -15,12 +15,12 @@ if (not can_fork()) {
 } elsif (!defined &Net::SSLeay::export_keying_material) {
     plan skip_all => "No export_keying_material()";
 } else {
-    plan tests => 37;
+    plan tests => 19;
 }
 
 initialise_libssl();
 
-my @rounds = qw( TLSv1 TLSv1.1 TLSv1.2 TLSv1.3 );
+my @rounds = qw( TLSv1.2 TLSv1.3 );
 
 my %usable =
     map {


### PR DESCRIPTION
Patches were taken unchanged from Oracle's perl-Net-SSLeay RPM.